### PR TITLE
remove travis-deploy-once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 node_js:
   - '8'
 after_success:
-  - npm run travis-deploy-once "npm run semantic-release"
+  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "nodemon": "^1.17.2",
     "smee-client": "^1.0.1",
     "standard": "^11.0.1",
-    "travis-deploy-once": "^5.0.0",
     "semantic-release": "^15.6.0"
   },
   "engines": {


### PR DESCRIPTION
See https://github.com/semantic-release/travis-deploy-once#readme, it’s only needed if you have multiple builds. Let me know if you have any questions @aps120797 