### PR TITLE
Include index.js in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "verbose": true,
     "testURL": "http://localhost/",
     "collectCoverageFrom": [
-      "src/**/*.js"
+      "src/**/*.js",
+      "index.js"
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true


### PR DESCRIPTION
I think this is the only file which is not currently included as part of the ""src/**/*.js" pattern in `package.json`