### PR TITLE
Ignore issue if it is a Pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 .vscode
 .vs
 coverage
+.idea

--- a/src/markdown/markdownIssues.js
+++ b/src/markdown/markdownIssues.js
@@ -1,4 +1,3 @@
-
 const moment = require('moment')
 
 module.exports = (issues, headDate, tailDate) => {
@@ -9,11 +8,10 @@ module.exports = (issues, headDate, tailDate) => {
     data = []
   }
   data = data.filter((item) => {
-    if (moment(item.created_at).isBetween(tailDate, headDate) && (item.user.login !== 'weekly-digest[bot]')) {
-      return true
-    } else {
-      return false
-    }
+    const itemCreatedAt = moment(item.created_at)
+    const isWeeklyDigest = (item.user.login === 'weekly-digest[bot]')
+    const isPullRequest = item.hasOwnProperty('pull_request')
+    return itemCreatedAt.isBetween(tailDate, headDate) && !isWeeklyDigest && !isPullRequest
   })
   if (data.length === 0) {
     issuesString += `Last week, no issues were created.\n`


### PR DESCRIPTION
According to the Github API docs the Issues endpoint also returns Pull requests: https://developer.github.com/v3/issues/?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc#list-issues

This PR adds an extra filter that removes PR's from the list of Issues. More info can be found in the issue I made #72 

Fixes #72 